### PR TITLE
WIP: Fix cluster annotations duplications (hulab/ClusterKit dependency)

### DIFF
--- a/ClusterKit/Core/CKClusterManager.m
+++ b/ClusterKit/Core/CKClusterManager.m
@@ -307,9 +307,8 @@ BOOL CLLocationCoordinateEqual(CLLocationCoordinate2D coordinate1, CLLocationCoo
         }
     }
     
-    [self.map performAnimations:animations.allObjects completion:^(BOOL finished) {
-        [self.map removeClusters:oldClusters];
-    }];
+    [self.map performAnimations:animations.allObjects completion:nil];
+    [self.map removeClusters:oldClusters];
 }
 
 #pragma mark <KPAnnotationTreeDelegate>


### PR DESCRIPTION
Remove old clusters from the map before the animation of collapsing clusters is completed.

https://issue.swisscom.ch/browse/MYCLOUDDEV-16061

The duplications were created since we were requesting annotations from the map before the animation has completed. The funny fact is that the issue is only in the method `-collapse:to:in:` but its opposite counterpart `-expand:from:in:` has correct logic!