### PR TITLE
Fix cluster annotations duplications (hulab/ClusterKit dependency)

### DIFF
--- a/ClusterKit/Core/CKClusterManager.h
+++ b/ClusterKit/Core/CKClusterManager.h
@@ -98,6 +98,11 @@ FOUNDATION_EXTERN const double kCKMarginFactorWorld;
 @property (nonatomic, readonly, copy) NSArray<CKCluster *> *clusters;
 
 /**
+ The array of clusters that are currently visible on the map.
+ */
+@property (nonatomic, readonly, copy) NSArray<CKCluster *> *visibleClusters;
+
+/**
  The maximum zoom level for clustering, 20 by default.
  */
 @property (nonatomic) CGFloat maxZoomLevel;

--- a/ClusterKit/Core/CKClusterManager.m
+++ b/ClusterKit/Core/CKClusterManager.m
@@ -97,6 +97,23 @@ BOOL CLLocationCoordinateEqual(CLLocationCoordinate2D coordinate1, CLLocationCoo
     return _clusters.allObjects;
 }
 
+- (NSArray<CKCluster *> *)visibleClusters {
+    NSMutableArray<CKCluster *> *result = [NSMutableArray<CKCluster *> new];
+
+    if (!self.map) return [result copy];
+
+    MKMapRect visibleMapRect = self.map.visibleMapRect;
+
+    NSArray<id<MKAnnotation>> *visibleAnnotations = [self.tree annotationsInRect:visibleMapRect];
+    NSSet<id<MKAnnotation>> *visibleAnnotationsSet = [NSSet setWithArray:visibleAnnotations];
+    for (CKCluster *cluster in _clusters) {
+        if ([visibleAnnotationsSet containsObject:cluster.firstAnnotation]) {
+            [result addObject:cluster];
+        }
+    }
+    return [result copy];
+}
+
 #pragma mark Manage Annotations
 
 - (void)setAnnotations:(NSArray<id<MKAnnotation>> *)annotations {


### PR DESCRIPTION
https://issue.swisscom.ch/browse/MYCLOUDDEV-16061

Add read-only property returning an array of the clusters within the visible map area.
This allows using this property in our code without waiting for completing of animations on the map view.